### PR TITLE
establish working definition of group

### DIFF
--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -17,16 +17,16 @@ namespace Defs
 
   class Monoid (G : Type*) extends Semigroup G where
     protected id : G
-    protected mul_id : ∀ a : G, a ⋆ id = a
-    protected id_mul : ∀ a : G, id ⋆ a = a
+    protected op_id : ∀ a : G, a ⋆ id = a
+    protected id_op : ∀ a : G, id ⋆ a = a
 
   notation:max "𝕖" => Monoid.id
 
   @[simp]
-  theorem mul_id [Monoid M] (a : M) : a ⋆ 𝕖 = a := Monoid.mul_id a
+  theorem op_id [Monoid M] (a : M) : a ⋆ 𝕖 = a := Monoid.op_id a
 
   @[simp]
-  theorem id_mul [Monoid M] (a : M) : 𝕖 ⋆ a = a := Monoid.id_mul a
+  theorem id_op [Monoid M] (a : M) : 𝕖 ⋆ a = a := Monoid.id_op a
 
   class CommMonoid (G : Type*) extends Monoid G where
     protected comm : ∀ a b : G, a ⋆ b = b ⋆ a
@@ -36,14 +36,14 @@ namespace Defs
 
   class Group (G : Type*) extends Monoid G where
     protected inv : G → G
-    protected inv_mul : ∀ a : G, (inv a) ⋆ a = 𝕖
-    -- protected mul_inv : ∀ a : G, a ⋆ (inv a) = 𝕖
+    protected inv_op : ∀ a : G, (inv a) ⋆ a = 𝕖
+    -- protected op_inv : ∀ a : G, a ⋆ (inv a) = 𝕖
 
   -- TODO: solve notational debate
   postfix:1023 "⁻¹" => Group.inv
 
   @[simp]
-  theorem inv_mul [Group G] (a : G) : a⁻¹ ⋆ a = 𝕖 := Group.inv_mul a
+  theorem inv_op [Group G] (a : G) : a⁻¹ ⋆ a = 𝕖 := Group.inv_op a
 
   class AbelianGroup (G : Type*) extends Group G, CommMonoid G
 

--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -1,1 +1,56 @@
-def hello := "world"
+import Mathlib.Tactic
+
+namespace Defs
+  class Magma (G : Type*) where
+    op : G → G → G
+
+  attribute [always_inline] Magma.op
+
+  infixl:75 " ⋆ " => Magma.op
+
+  class Semigroup (G : Type*) extends Magma G where
+    protected assoc : ∀ a b c : G, (a ⋆ b) ⋆ c = a ⋆ (b ⋆ c)
+
+  @[simp]
+  theorem assoc [Semigroup G] (a b c : G) : (a ⋆ b) ⋆ c = a ⋆ (b ⋆ c) := Semigroup.assoc a b c
+
+  class Monoid (G : Type*) extends Semigroup G where
+    protected id : G
+    protected mul_id : ∀ a : G, a ⋆ id = a
+    protected id_mul : ∀ a : G, id ⋆ a = a
+
+  notation:max "𝕖" => Monoid.id
+
+  @[simp]
+  theorem mul_id [Monoid M] (a : M) : a ⋆ 𝕖 = a := Monoid.mul_id a
+
+  @[simp]
+  theorem id_mul [Monoid M] (a : M) : 𝕖 ⋆ a = a := Monoid.id_mul a
+
+  class CommMonoid (G : Type*) extends Monoid G where
+    protected comm : ∀ a b : G, a ⋆ b = b ⋆ a
+
+  @[simp]
+  theorem comm [CommMonoid M] (a b : M) : a ⋆ b = b ⋆ a := CommMonoid.comm a b
+
+  class Group (G : Type*) extends Monoid G where
+    protected inv : G → G
+    protected inv_mul : ∀ a : G, (inv a) ⋆ a = 𝕖
+    -- protected mul_inv : ∀ a : G, a ⋆ (inv a) = 𝕖
+
+  -- TODO: solve notational debate
+  postfix:1023 "⁻¹" => Group.inv
+
+  @[simp]
+  theorem inv_mul [Group G] (a : G) : a⁻¹ ⋆ a = 𝕖 := Group.inv_mul a
+
+  @[simp]
+  theorem mul_inv [Group G] (a : G) : a ⋆ a⁻¹ = 𝕖 := by
+    -- apply Group.cancel_left a⁻¹
+    -- rw [←assoc, inv_mul, mul_id, id_mul]
+    -- done
+    sorry
+
+  class AbelianGroup (G : Type*) extends Group G, CommMonoid G
+
+end Defs

--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -45,13 +45,6 @@ namespace Defs
   @[simp]
   theorem inv_mul [Group G] (a : G) : a⁻¹ ⋆ a = 𝕖 := Group.inv_mul a
 
-  @[simp]
-  theorem mul_inv [Group G] (a : G) : a ⋆ a⁻¹ = 𝕖 := by
-    -- apply Group.cancel_left a⁻¹
-    -- rw [←assoc, inv_mul, mul_id, id_mul]
-    -- done
-    sorry
-
   class AbelianGroup (G : Type*) extends Group G, CommMonoid G
 
 end Defs

--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -4,9 +4,6 @@ namespace Defs
   class Magma (G : Type*) where
     op : G → G → G
 
-  -- FIXME: is this actually helpful/necessary
-  attribute [always_inline] Magma.op
-
   def μ [Magma G] : G → G → G := Magma.op
 
   class Semigroup (G : Type*) extends Magma G where

--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -7,10 +7,10 @@ namespace Defs
   def μ [Magma G] : G → G → G := Magma.op
 
   class Semigroup (G : Type*) extends Magma G where
-    protected assoc : ∀ a b c : G, μ (μ a b) c = μ a (μ b c)
+    protected op_assoc : ∀ a b c : G, μ (μ a b) c = μ a (μ b c)
 
   @[simp]
-  theorem assoc [Semigroup G] (a b c : G) : μ (μ a b) c = μ a (μ b c) := Semigroup.assoc a b c
+  theorem op_assoc [Semigroup G] (a b c : G) : μ (μ a b) c = μ a (μ b c) := Semigroup.op_assoc a b c
 
   class Monoid (G : Type*) extends Semigroup G where
     protected id : G
@@ -26,10 +26,10 @@ namespace Defs
   theorem id_op [Monoid M] (a : M) : μ 𝕖 a = a := Monoid.id_op a
 
   class CommMonoid (G : Type*) extends Monoid G where
-    protected comm : ∀ a b : G, μ a b = μ b a
+    protected op_comm : ∀ a b : G, μ a b = μ b a
 
   @[simp]
-  theorem comm [CommMonoid M] (a b : M) : μ a b = μ b a := CommMonoid.comm a b
+  theorem op_comm [CommMonoid M] (a b : M) : μ a b = μ b a := CommMonoid.op_comm a b
 
   class Group (G : Type*) extends Monoid G where
     protected inv : G → G

--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -4,6 +4,7 @@ namespace Defs
   class Magma (G : Type*) where
     op : G → G → G
 
+  -- FIXME: is this actually helpful/necessary
   attribute [always_inline] Magma.op
 
   infixl:75 " ⋆ " => Magma.op

--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -7,43 +7,42 @@ namespace Defs
   -- FIXME: is this actually helpful/necessary
   attribute [always_inline] Magma.op
 
-  infixl:75 " ⋆ " => Magma.op
+  def μ [Magma G] : G → G → G := Magma.op
 
   class Semigroup (G : Type*) extends Magma G where
-    protected assoc : ∀ a b c : G, (a ⋆ b) ⋆ c = a ⋆ (b ⋆ c)
+    protected assoc : ∀ a b c : G, μ (μ a b) c = μ a (μ b c)
 
   @[simp]
-  theorem assoc [Semigroup G] (a b c : G) : (a ⋆ b) ⋆ c = a ⋆ (b ⋆ c) := Semigroup.assoc a b c
+  theorem assoc [Semigroup G] (a b c : G) : μ (μ a b) c = μ a (μ b c) := Semigroup.assoc a b c
 
   class Monoid (G : Type*) extends Semigroup G where
     protected id : G
-    protected op_id : ∀ a : G, a ⋆ id = a
-    protected id_op : ∀ a : G, id ⋆ a = a
+    protected op_id : ∀ a : G, μ a id = a
+    protected id_op : ∀ a : G, μ id a = a
 
   notation:max "𝕖" => Monoid.id
 
   @[simp]
-  theorem op_id [Monoid M] (a : M) : a ⋆ 𝕖 = a := Monoid.op_id a
+  theorem op_id [Monoid M] (a : M) : μ a 𝕖 = a := Monoid.op_id a
 
   @[simp]
-  theorem id_op [Monoid M] (a : M) : 𝕖 ⋆ a = a := Monoid.id_op a
+  theorem id_op [Monoid M] (a : M) : μ 𝕖 a = a := Monoid.id_op a
 
   class CommMonoid (G : Type*) extends Monoid G where
-    protected comm : ∀ a b : G, a ⋆ b = b ⋆ a
+    protected comm : ∀ a b : G, μ a b = μ b a
 
   @[simp]
-  theorem comm [CommMonoid M] (a b : M) : a ⋆ b = b ⋆ a := CommMonoid.comm a b
+  theorem comm [CommMonoid M] (a b : M) : μ a b = μ b a := CommMonoid.comm a b
 
   class Group (G : Type*) extends Monoid G where
     protected inv : G → G
-    protected inv_op : ∀ a : G, (inv a) ⋆ a = 𝕖
-    -- protected op_inv : ∀ a : G, a ⋆ (inv a) = 𝕖
+    protected inv_op : ∀ a : G, μ (inv a) a = 𝕖
+    -- protected op_inv : ∀ a : G, μ a (inv a) = 𝕖
 
-  -- TODO: solve notational debate
-  postfix:1023 "⁻¹" => Group.inv
+  def ι [Group G] : G → G := Group.inv
 
   @[simp]
-  theorem inv_op [Group G] (a : G) : a⁻¹ ⋆ a = 𝕖 := Group.inv_op a
+  theorem inv_op [Group G] (a : G) : μ (ι a) a = 𝕖 := Group.inv_op a
 
   class AbelianGroup (G : Type*) extends Group G, CommMonoid G
 

--- a/AlgebraInLean/Basic.lean
+++ b/AlgebraInLean/Basic.lean
@@ -20,7 +20,7 @@ namespace Defs
     protected op_id : ∀ a : G, μ a id = a
     protected id_op : ∀ a : G, μ id a = a
 
-  notation:max "𝕖" => Monoid.id
+  def 𝕖 [Monoid G] : G := Monoid.id
 
   @[simp]
   theorem op_id [Monoid M] (a : M) : μ a 𝕖 = a := Monoid.op_id a


### PR DESCRIPTION
These will be the working definitions and notations that we will use for the entirety of the project. Chapter 1 should build up to these definitions, possibly using definitions of their own, while chapters 2 and onward should use these definitions in future theorems.

The namespace in which these definitions are located is meant to be temporary, as it will be moved into a chapter once the structure of the project becomes more concrete.

Once we agree, let's merge this PR so that it's only one commit, sqaushing it if necessary.