### PR TITLE
CI/CD : lake build with `--wfail` only on `master`

### DIFF
--- a/.github/workflows/build-strict.yml
+++ b/.github/workflows/build-strict.yml
@@ -1,8 +1,10 @@
-name: build
+name: build-strict
 
 on:
   push:
+    branches: [ "master" ]
   pull_request:
+    branches: [ "master" ]
   workflow_dispatch:
 
 jobs:
@@ -41,4 +43,4 @@ jobs:
           lake build ProofWidgets
 
       - name: build project
-        run: lake build
+        run: lake build --wfail


### PR DESCRIPTION
As people build on their own separate branches, those working on the later chapters will likely depend on definitions and results discussed and proven in previous chapters. As a result, to avoid authors of later chapters worrying about proofs of earlier results, these authors are likely to use `sorry` on their personal branches. That being said, we should still disallow the use of `sorry` on the master branch.

To solve this, we run `lake build` twice in two separate tests: one build is more permissive (allows `sorry`), and runs on every branch. The more strict `lake build --wfail` (disallows `sorry`) will only run on `master` and its pull request.