### PR TITLE
disable `unusedTactic` linter for every file

### DIFF
--- a/AlgebraInLean/Chapter00/Sheet01.lean
+++ b/AlgebraInLean/Chapter00/Sheet01.lean
@@ -4,6 +4,7 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+set_option linter.unusedTactic false
 /-
 Welcome!
 

--- a/AlgebraInLean/Chapter00/Sheet02.lean
+++ b/AlgebraInLean/Chapter00/Sheet02.lean
@@ -4,6 +4,16 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+/-
+The `linter.unusedTactic` command permits the usage of the `done` tactic without warnings. You will
+see this in every sheet.
+
+FIXME: Find a more optimal solution for disabling this linter globally.
+-/
+set_option linter.unusedTactic false
+/-
+The `linter.unusedVariables` command ignores unused variables warnings in select sheets.
+-/
 set_option linter.unusedVariables false
 /-this allows us to define variables that go on to be unused in an exercise-/
 

--- a/AlgebraInLean/Chapter00/Sheet03.lean
+++ b/AlgebraInLean/Chapter00/Sheet03.lean
@@ -4,6 +4,7 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+set_option linter.unusedTactic false
 /-
 In the Natural Number Game, you used the tactics:
 

--- a/AlgebraInLean/Chapter00/Sheet04.lean
+++ b/AlgebraInLean/Chapter00/Sheet04.lean
@@ -4,6 +4,7 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+set_option linter.unusedTactic false
 /-
 The tactic `constructor` should be completely new to you. It is very useful for deconstructing
 goals that use `∧` ("and"). It is similar to the `cases` tactic in the way that it breaks up one

--- a/AlgebraInLean/Chapter00/Sheet05.lean
+++ b/AlgebraInLean/Chapter00/Sheet05.lean
@@ -5,7 +5,7 @@ This is a solutions sheet.
 import Mathlib.Tactic
 
 set_option linter.unusedVariables false
-
+set_option linter.unusedTactic false
 /-
 Let's wrap up our intro to Lean with some more straightforward tactics. We will quickly go over:
 


### PR DESCRIPTION
Fixes `build-strict` issue in chapter 0. This is meant to be a temporary fix until a solution for disabling this linter globally becomes known.