### PR TITLE
Fixed outdated terms and typos

### DIFF
--- a/AlgebraInLean/Chapter00/Sheet01.lean
+++ b/AlgebraInLean/Chapter00/Sheet01.lean
@@ -4,6 +4,7 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+set_option linter.unusedTactic false
 /-
 Welcome!
 

--- a/AlgebraInLean/Chapter00/Sheet01.lean
+++ b/AlgebraInLean/Chapter00/Sheet01.lean
@@ -13,26 +13,26 @@ proving theorems on groups, rings, and fields, you'll become comfortable with us
 you verify theorems in a user-friendly way.
 
 This problem set is written under the assumption that you, the user, have already completed the
-Natural Number Game: <https://adam.math.hhu.de/#/g/leanprover-community/nng4> Additionally, it is
+Natural Number Game: <https://adam.math.hhu.de/#/g/leanprover-community/nng4>. Additionally, it is
 assumed that the user is in the process of taking (or is already familiar with) an abstract algebra
 class, so explanations of concepts will be more concise than a textbook's.
 
 There are solutions provided for your reference. Should you be interested in learning more about
 specific tactics, Lean 4 documentation is available online.
 
-Learn about all things Lean 4 here: <https://leanprover-community.github.io/index.html> Full
-documentation can be found here: <https://leanprover-community.github.io/mathlib4_docs/>
+Learn about all things Lean 4 here: <https://leanprover-community.github.io/index.html>
+Full documentation can be found here: <https://leanprover-community.github.io/mathlib4_docs/>
 
 ****
 
-Before we dive into abstract algebra in World 1, we will begin with the basics of Lean in World 0.
-If you are already familiar with using Lean, feel free to skip World 0 and dive straight into World
-1. Additionally, if on any sheet you feel comfortable with a tactic, feel free to skip exercises and
-move on to learning the next one, as some exercises can be repetitive.
+Before we dive into abstract algebra in Chapter 1, we will begin with the basics of Lean in Chapter
+0. If you are already familiar with using Lean, feel free to skip Chapter 0 and dive straight into
+Chapter 1. Additionally, if on any sheet you feel comfortable with a tactic, feel free to skip
+exercises and move on to learning the next one, as some exercises can be repetitive.
 
-As you saw in the Natural Number Game, in Lean, theorems are proven using the help of tactics. World
-0 will familiarize you with a few basic tactics through some exercises concerning logic and basic
-arithmetic.
+As you saw in the Natural Number Game, in Lean, theorems are proven using the help of tactics.
+Chapter 0 will familiarize you with a few basic tactics through some exercises concerning logic and
+basic arithmetic.
 
 To get you used to reading Lean, let us begin with a very basic exercise from the Natural Number
 Game.

--- a/AlgebraInLean/Chapter00/Sheet02.lean
+++ b/AlgebraInLean/Chapter00/Sheet02.lean
@@ -4,6 +4,16 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+/-
+The `linter.unusedTactic` command permits the usage of the `done` tactic without warnings. You will
+see this in every sheet.
+
+FIXME: Find a more optimal solution for disabling this linter globally.
+-/
+set_option linter.unusedTactic false
+/-
+The `linter.unusedVariables` command ignores unused variables warnings in select sheets.
+-/
 set_option linter.unusedVariables false
 /-this allows us to define variables that go on to be unused in an exercise-/
 

--- a/AlgebraInLean/Chapter00/Sheet03.lean
+++ b/AlgebraInLean/Chapter00/Sheet03.lean
@@ -4,6 +4,7 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+set_option linter.unusedTactic false
 /-
 In the Natural Number Game, you used the tactics:
 

--- a/AlgebraInLean/Chapter00/Sheet04.lean
+++ b/AlgebraInLean/Chapter00/Sheet04.lean
@@ -4,6 +4,7 @@ This is a solutions sheet.
 
 import Mathlib.Tactic
 
+set_option linter.unusedTactic false
 /-
 The tactic `constructor` should be completely new to you. It is very useful for deconstructing
 goals that use `∧` ("and"). It is similar to the `cases` tactic in the way that it breaks up one

--- a/AlgebraInLean/Chapter00/Sheet05.lean
+++ b/AlgebraInLean/Chapter00/Sheet05.lean
@@ -5,7 +5,7 @@ This is a solutions sheet.
 import Mathlib.Tactic
 
 set_option linter.unusedVariables false
-
+set_option linter.unusedTactic false
 /-
 Let's wrap up our intro to Lean with some more straightforward tactics. We will quickly go over:
 

--- a/AlgebraInLean/Chapter00/Sheet05.lean
+++ b/AlgebraInLean/Chapter00/Sheet05.lean
@@ -170,11 +170,12 @@ Note that there could be many solutions to any given exercise.
 Tactics like `assumption` and `specialize` are also helpful for dealing with multiple hypotheses.
 
 You now know enough tactics to progress beyond these simpler exercises to applying what you know
-about Lean to abstract algebra. In future worlds, we go beyond only working with the natural numbers
-or simple Prop variables to creating algebraic structures such as groups. This means that the types
-you will be working with will become more intricate and complex.
+about Lean to abstract algebra. In future chapters, we go beyond only working with the natural
+numbers or simple Prop variables to creating algebraic structures such as groups. This means that
+the types you will be working with will become more intricate and complex.
 
-The final sheet in World 0 is a list of tactics mentioned so far and is for your use as you see fit.
+The final sheet in Chapter 0 is a list of tactics mentioned so far and is for your use as you see
+fit.
 
-On to the next world!
+On to the next chapter!
 -/

--- a/AlgebraInLean/Chapter00/Sheet06.lean
+++ b/AlgebraInLean/Chapter00/Sheet06.lean
@@ -5,8 +5,8 @@ This is a solutions sheet.
 /-
 Tactics!
 
-Below is a list of tactics mentioned in World 0. Feel free to use this list for reference to write
-notes, or keep updating it with tactics mentioned in future worlds.
+Below is a list of tactics mentioned in Chapter 0. Feel free to use this list for reference to write
+notes, or keep updating it with tactics mentioned in future chapters.
 
 This cheatsheet from Formalising Mathematics might also be helpful:
 <https://www.ma.imperial.ac.uk/~buzzard/xena/formalising-mathematics-2024/Part_C/cheatsheet.html>


### PR DESCRIPTION
Fixes typos, mainly:

- Fixes instances in Chapter 00 which refer to "chapters" as "worlds"
- Fixes grammatical typo