### PR TITLE
fill `sorry`s in chapter 3 sheet 3

### DIFF
--- a/AlgebraInLean/Chapter03/Sheet02.lean
+++ b/AlgebraInLean/Chapter03/Sheet02.lean
@@ -236,6 +236,14 @@ lemma gpow_sub (m n : ℤ) : μ (gpow x m) (ι (gpow x n)) = gpow x (m - n) := b
   -- EXERCISE (*)
   rw [sub_eq_add_neg, ←gpow_add, gpow_neg]
 
+
+lemma gpow_mul (m n : ℤ) : gpow x (m * n) = gpow (gpow x m) n := by
+  -- EXERCISE (*)
+  induction n using Int.induction_on with
+  | hz => rw [mul_zero, gpow_zero, gpow_zero]
+  | hp n ih => rw [mul_add, mul_one, ←gpow_add, gpow_succ, ih]
+  | hn n ih => rw [Int.mul_sub, mul_one, ←gpow_sub, ←gpow_pred, ih]
+
 -- The first thing we will prove about `gpow` is that subgroups are closed under the function.
 theorem gpow_closure {H : Subgroup G} {n : ℤ}: x ∈ H → gpow x n ∈ H := by
   -- EXERCISE (*)

--- a/blueprint/src/chapters/chapter3/sheet3.tex
+++ b/blueprint/src/chapters/chapter3/sheet3.tex
@@ -7,3 +7,14 @@
     \uses{definition : mpow}
     Let $M$ be a monoid and $x \in M$. Then the \textit{order} of $x$, denoted $|x|$, is the smallest $n \in \mathbb{N}$ satisfying $x^n = \mathbb{e}$. If no such $n$ exists, then we define the order of $x$ to be zero.
 \end{definition}
+
+\begin{theorem}
+    \label{theorem : mod_order_eq_of_gpow_eq}
+    \lean{AlgebraInLean.mod_order_eq_of_gpow_eq}
+    \leanok
+    \uses{definition : gpow, definition : order}
+    Let $G$ be a group and $x \in G$. Suppose that for two integers $m$ and $n$,
+    $x^m = x^n$. Then $m \equiv n$ (mod $|x|$). Note that if two integers
+    are equivalent mod 0, then they are equal, implying that if $|x| = 0$, then
+    the power function over $\mathbb{Z}$ is injective.
+\end{theorem}


### PR DESCRIPTION
Closes #43.

Perhaps, once pushed, we rebase `master` so that the content of this commit is squashed into the chapter 3 commit? This is bad practice, but it does cause nicer commit history on `master`...